### PR TITLE
Add SetRequestHeaders function to set necessary HTTP headers***

### DIFF
--- a/httpclient/httpclient_headers.go
+++ b/httpclient/httpclient_headers.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/deploymenttheory/go-api-http-client/logger"
+	"go.uber.org/zap"
 )
 
 // HeadersToString converts an http.Header map to a single string representation.
@@ -18,4 +21,48 @@ func HeadersToString(headers http.Header) string {
 
 	// Join all header strings into a single string
 	return strings.Join(headerStrings, "; ")
+}
+
+// SetRequestHeaders sets the necessary HTTP headers for a given request. It configures the Authorization,
+// Content-Type, and Accept headers based on the client's current token, the content type specified by the
+// caller, and the preferred response formats defined by the APIHandler's GetAcceptHeader method.
+// Additionally, it sets a User-Agent header to identify the client making the request.
+// If debug logging is enabled, the function logs all set headers, with sensitive information such as the
+// Authorization token being redacted for security purposes.
+//
+// Parameters:
+// - req: The *http.Request object to which headers will be added. This request is prepared by the caller
+// and passed to SetRequestHeaders for header configuration.
+//
+// - contentType: A string specifying the content type of the request, typically determined by the APIHandler's
+// logic based on the request's nature and the endpoint being accessed.
+//
+// - acceptHeader: A string specifying the Accept header value, which is obtained from the APIHandler's
+// GetAcceptHeader method. This header indicates the MIME types that the client can process, with preferences
+// expressed through quality factors (q-values).
+//
+// - log: A logger.Logger instance used for logging header information when debug logging is enabled. The
+// logger's level controls whether headers are logged, with logging occurring only at LogLevelDebug or lower.
+//
+// The function leverages the APIHandler interface to dynamically determine the appropriate Accept header,
+// ensuring compatibility with the API's supported response formats. This approach allows for flexible and
+// context-aware setting of request headers, facilitating effective communication with diverse APIs managed
+// by different handlers, such as the JamfAPIHandler example provided in the api_handler.go file.
+func (c *Client) SetRequestHeaders(req *http.Request, contentType, acceptHeader string, log logger.Logger) {
+	// Set Headers
+	req.Header.Add("Authorization", "Bearer "+c.Token)
+	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("Accept", acceptHeader)
+	req.Header.Set("User-Agent", GetUserAgentHeader())
+
+	// Debug: Print request headers if debug logging is enabled
+	if log.GetLogLevel() <= logger.LogLevelDebug {
+		redactedAuthorization := RedactSensitiveData(c, "Authorization", req.Header.Get("Authorization"))
+		log.Debug("HTTP Request Headers",
+			zap.String("Authorization", redactedAuthorization),
+			zap.String("Content-Type", req.Header.Get("Content-Type")),
+			zap.String("Accept", req.Header.Get("Accept")),
+			zap.String("User-Agent", req.Header.Get("User-Agent")),
+		)
+	}
 }

--- a/httpclient/httpclient_request.go.backup
+++ b/httpclient/httpclient_request.go.backup
@@ -95,12 +95,23 @@ func (c *Client) DoRequest(method, endpoint string, body, out interface{}, log l
 
 	// Define header content type based on url and http method
 	contentType := apiHandler.GetContentTypeHeader(endpoint, log)
-
-	// Get Request Headers dynamically based on api handler
+	// Define Request Headers dynamically based on handler logic
 	acceptHeader := apiHandler.GetAcceptHeader()
 
-	// Set Request Headers
-	c.SetRequestHeaders(req, contentType, acceptHeader, log)
+	// Set Headers
+	req.Header.Add("Authorization", "Bearer "+c.Token)
+	req.Header.Add("Content-Type", contentType)
+	req.Header.Add("Accept", acceptHeader)
+	req.Header.Set("User-Agent", GetUserAgentHeader())
+
+	// Debug: Print request headers
+	redactedAuthorization := RedactSensitiveData(c, "Authorization", req.Header.Get("Authorization"))
+	c.Logger.Debug("HTTP Request Headers",
+		zap.String("Authorization", redactedAuthorization),
+		zap.String("Content-Type", req.Header.Get("Content-Type")),
+		zap.String("Accept", req.Header.Get("Accept")),
+		zap.String("User-Agent", req.Header.Get("User-Agent")),
+	)
 
 	// Define if request is retryable
 	retryableHTTPMethods := map[string]bool{
@@ -359,11 +370,19 @@ func (c *Client) DoMultipartRequest(method, endpoint string, fields map[string]s
 		return nil, err
 	}
 
-	// Get Request Headers dynamically based on api handler
-	acceptHeader := apiHandler.GetAcceptHeader()
-
 	// Set Request Headers
-	c.SetRequestHeaders(req, contentType, acceptHeader, log)
+	req.Header.Add("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", GetUserAgentHeader())
+
+	// Debug: Print request headers
+	redactedAuthorization := RedactSensitiveData(c, "Authorization", req.Header.Get("Authorization"))
+	c.Logger.Debug("HTTP Request Headers",
+		zap.String("Authorization", redactedAuthorization),
+		zap.String("Content-Type", req.Header.Get("Content-Type")),
+		zap.String("Accept", req.Header.Get("Accept")),
+		zap.String("User-Agent", req.Header.Get("User-Agent")),
+	)
 
 	// Execute the request
 	resp, err := c.httpClient.Do(req)


### PR DESCRIPTION
***This commit adds a new function SetRequestHeaders to the httpclient package. The function sets the necessary HTTP headers for a given request, including the Authorization, Content-Type, Accept, and User-Agent headers. It also logs the set headers when debug logging is enabled. This function improves header configuration and enhances communication with diverse APIs managed by different handlers.

# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Please **DELETE** options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
