### PR TITLE
Moved error responses from the api integration to a centralised response package

### DIFF
--- a/apiintegrations/apihandler/apihandler.go
+++ b/apiintegrations/apihandler/apihandler.go
@@ -18,7 +18,7 @@ type APIHandler interface {
 	MarshalRequest(body interface{}, method string, endpoint string, log logger.Logger) ([]byte, error)
 	MarshalMultipartRequest(fields map[string]string, files map[string]string, log logger.Logger) ([]byte, string, error)
 	HandleAPISuccessResponse(resp *http.Response, out interface{}, log logger.Logger) error
-	HandleAPIErrorResponse(resp *http.Response, out interface{}, log logger.Logger) error
+	//HandleAPIErrorResponse(resp *http.Response, out interface{}, log logger.Logger) error
 	GetContentTypeHeader(method string, log logger.Logger) string
 	GetAcceptHeader() string
 	GetDefaultBaseDomain() string

--- a/apiintegrations/jamfpro/jamfpro_api_response.go
+++ b/apiintegrations/jamfpro/jamfpro_api_response.go
@@ -41,37 +41,6 @@ func (j *JamfAPIHandler) HandleAPISuccessResponse(resp *http.Response, out inter
 	return j.unmarshalResponse(contentType, bodyBytes, out)
 }
 
-func (j *JamfAPIHandler) HandleAPIErrorResponse(resp *http.Response, out interface{}, log logger.Logger) error {
-	// Read the response body
-	bodyBytes, err := j.readResponseBody(resp)
-	if err != nil {
-		return err
-	}
-
-	// Convert bodyBytes to a string to represent the raw response body
-	rawResponse := string(bodyBytes)
-
-	// Log the raw response details for debugging
-	j.logResponseDetails(resp, bodyBytes)
-
-	// Get the content type from the response headers
-	contentType := resp.Header.Get("Content-Type")
-
-	// Handle known error content types (e.g., JSON, HTML)
-	if strings.Contains(contentType, "application/json") {
-		return j.handleErrorJSONResponse(bodyBytes, resp.StatusCode, rawResponse)
-	} else if strings.Contains(contentType, "text/html") {
-		return j.handleErrorHTMLResponse(bodyBytes, resp.StatusCode)
-	}
-
-	// Generic error handling for unknown content types
-	j.Logger.Error("Received non-success status code without detailed error response",
-		zap.Int("status_code", resp.StatusCode),
-		zap.String("raw_response", rawResponse),
-	)
-	return fmt.Errorf("received non-success status code: %d, raw response: %s", resp.StatusCode, rawResponse)
-}
-
 // handleDeleteRequest handles the special case for DELETE requests, where a successful response might not contain a body.
 func (j *JamfAPIHandler) handleDeleteRequest(resp *http.Response) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
@@ -124,40 +93,71 @@ func (j *JamfAPIHandler) handleBinaryData(contentType, contentDisposition string
 	return nil // If not binary data, no action needed
 }
 
+// func (j *JamfAPIHandler) HandleAPIErrorResponse(resp *http.Response, out interface{}, log logger.Logger) error {
+// 	// Read the response body
+// 	bodyBytes, err := j.readResponseBody(resp)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	// Convert bodyBytes to a string to represent the raw response body
+// 	rawResponse := string(bodyBytes)
+
+// 	// Log the raw response details for debugging
+// 	j.logResponseDetails(resp, bodyBytes)
+
+// 	// Get the content type from the response headers
+// 	contentType := resp.Header.Get("Content-Type")
+
+// 	// Handle known error content types (e.g., JSON, HTML)
+// 	if strings.Contains(contentType, "application/json") {
+// 		return j.handleErrorJSONResponse(bodyBytes, resp.StatusCode, rawResponse)
+// 	} else if strings.Contains(contentType, "text/html") {
+// 		return j.handleErrorHTMLResponse(bodyBytes, resp.StatusCode)
+// 	}
+
+// 	// Generic error handling for unknown content types
+// 	j.Logger.Error("Received non-success status code without detailed error response",
+// 		zap.Int("status_code", resp.StatusCode),
+// 		zap.String("raw_response", rawResponse),
+// 	)
+// 	return fmt.Errorf("received non-success status code: %d, raw response: %s", resp.StatusCode, rawResponse)
+// }
+
 // handleErrorHTMLResponse handles error responses with HTML content by extracting and logging the error message.
-func (j *JamfAPIHandler) handleErrorHTMLResponse(bodyBytes []byte, statusCode int) error {
-	// Extract the error message from the HTML content
-	htmlErrorMessage := ExtractErrorMessageFromHTML(string(bodyBytes))
-	// Log the error message along with the status code
-	j.Logger.Error("Received HTML error content",
-		zap.String("error_message", htmlErrorMessage),
-		zap.Int("status_code", statusCode),
-	)
-	// Return an error with the extracted message
-	return fmt.Errorf("received HTML error content: %s", htmlErrorMessage)
-}
+// func (j *JamfAPIHandler) handleErrorHTMLResponse(bodyBytes []byte, statusCode int) error {
+// 	// Extract the error message from the HTML content
+// 	htmlErrorMessage := ExtractErrorMessageFromHTML(string(bodyBytes))
+// 	// Log the error message along with the status code
+// 	j.Logger.Error("Received HTML error content",
+// 		zap.String("error_message", htmlErrorMessage),
+// 		zap.Int("status_code", statusCode),
+// 	)
+// 	// Return an error with the extracted message
+// 	return fmt.Errorf("received HTML error content: %s", htmlErrorMessage)
+// }
 
 // handleErrorJSONResponse handles error responses with JSON content by parsing the error message and logging it.
-func (j *JamfAPIHandler) handleErrorJSONResponse(bodyBytes []byte, statusCode int, rawResponse string) error {
-	// Parse the JSON error response to extract the error description
-	description, err := ParseJSONErrorResponse(bodyBytes)
-	if err != nil {
-		// Log the parsing error
-		j.Logger.Error("Failed to parse JSON error response",
-			zap.Error(err),
-			zap.Int("status_code", statusCode),
-			zap.String("raw_response", rawResponse), // Include raw response in the log
-		)
-		return fmt.Errorf("failed to parse JSON error response: %v, raw response: %s", err, rawResponse)
-	}
-	// Log the error description along with the status code and raw response
-	j.Logger.Error("Received non-success status code with JSON response",
-		zap.Int("status_code", statusCode),
-		zap.String("error_description", description),
-		zap.String("raw_response", rawResponse), // Include raw response in the log
-	)
-	return fmt.Errorf("received non-success status code with JSON response: %s, raw response: %s", description, rawResponse)
-}
+// func (j *JamfAPIHandler) handleErrorJSONResponse(bodyBytes []byte, statusCode int, rawResponse string) error {
+// 	// Parse the JSON error response to extract the error description
+// 	description, err := ParseJSONErrorResponse(bodyBytes)
+// 	if err != nil {
+// 		// Log the parsing error
+// 		j.Logger.Error("Failed to parse JSON error response",
+// 			zap.Error(err),
+// 			zap.Int("status_code", statusCode),
+// 			zap.String("raw_response", rawResponse), // Include raw response in the log
+// 		)
+// 		return fmt.Errorf("failed to parse JSON error response: %v, raw response: %s", err, rawResponse)
+// 	}
+// 	// Log the error description along with the status code and raw response
+// 	j.Logger.Error("Received non-success status code with JSON response",
+// 		zap.Int("status_code", statusCode),
+// 		zap.String("error_description", description),
+// 		zap.String("raw_response", rawResponse), // Include raw response in the log
+// 	)
+// 	return fmt.Errorf("received non-success status code with JSON response: %s, raw response: %s", description, rawResponse)
+// }
 
 // unmarshalResponse unmarshals the response body into the provided output structure based on the content type (JSON or XML).
 func (j *JamfAPIHandler) unmarshalResponse(contentType string, bodyBytes []byte, out interface{}) error {

--- a/httpclient/multipartrequest.go
+++ b/httpclient/multipartrequest.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/deploymenttheory/go-api-http-client/authenticationhandler"
 	"github.com/deploymenttheory/go-api-http-client/headers"
+	"github.com/deploymenttheory/go-api-http-client/response"
 )
 
 // DoMultipartRequest creates and executes a multipart HTTP request. It is used for sending files
@@ -86,7 +87,7 @@ func (c *Client) DoMultipartRequest(method, endpoint string, fields map[string]s
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Handle error responses
 		//return nil, c.handleErrorResponse(resp, log, "Failed to process the HTTP request", method, endpoint)
-		return nil, c.handleErrorResponse(resp, out, log, method, endpoint)
+		return nil, response.HandleAPIErrorResponse(resp, log)
 	} else {
 		// Handle successful responses
 		return resp, c.handleSuccessResponse(resp, out, log, method, endpoint)

--- a/httpclient/request.go
+++ b/httpclient/request.go
@@ -400,22 +400,22 @@ func (c *Client) do(req *http.Request, log logger.Logger, method, endpoint strin
 //
 // Returns:
 // - An error object parsed from the HTTP response, indicating the nature of the failure.
-func (c *Client) handleErrorResponse(resp *http.Response, out interface{}, log logger.Logger, method, endpoint string) error {
-	if err := c.APIHandler.HandleAPIErrorResponse(resp, out, log); err != nil {
-		log.Error("Failed to unmarshal HTTP response",
-			zap.String("method", method),
-			zap.String("endpoint", endpoint),
-			zap.Error(err),
-		)
-		return err
-	}
-	log.Info("HTTP request succeeded",
-		zap.String("method", method),
-		zap.String("endpoint", endpoint),
-		zap.Int("status_code", resp.StatusCode),
-	)
-	return nil
-}
+// func (c *Client) handleErrorResponse(resp *http.Response, out interface{}, log logger.Logger, method, endpoint string) error {
+// 	if err := c.APIHandler.HandleAPIErrorResponse(resp, out, log); err != nil {
+// 		log.Error("Failed to unmarshal HTTP response",
+// 			zap.String("method", method),
+// 			zap.String("endpoint", endpoint),
+// 			zap.Error(err),
+// 		)
+// 		return err
+// 	}
+// 	log.Info("HTTP request succeeded",
+// 		zap.String("method", method),
+// 		zap.String("endpoint", endpoint),
+// 		zap.Int("status_code", resp.StatusCode),
+// 	)
+// 	return nil
+// }
 
 // handleSuccessResponse unmarshals a successful HTTP response into the provided output parameter and logs the
 // success details. It's designed for use when the response indicates success (status code within 200-299).

--- a/response/error.go
+++ b/response/error.go
@@ -170,11 +170,19 @@ func parseHTMLResponse(bodyBytes []byte, apiError *APIError, log logger.Logger, 
 	var parse func(*html.Node)
 	parse = func(n *html.Node) {
 		if n.Type == html.ElementNode && n.Data == "p" {
+			var pText strings.Builder
 			for c := n.FirstChild; c != nil; c = c.NextSibling {
-				if c.Type == html.TextNode {
-					// Accumulate text content of <p> tag
-					messages = append(messages, c.Data)
+				if c.Type == html.TextNode && strings.TrimSpace(c.Data) != "" {
+					// Build text content of <p> tag
+					if pText.Len() > 0 {
+						pText.WriteString(" ") // Add a space between text nodes within the same <p> tag
+					}
+					pText.WriteString(strings.TrimSpace(c.Data))
 				}
+			}
+			if pText.Len() > 0 {
+				// Add the built text content of the <p> tag to messages
+				messages = append(messages, pText.String())
 			}
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {


### PR DESCRIPTION
# Change

Moved error responses from the api integration to a centralised response package

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [ ] I did format my code
