### PR TITLE
Add OAuth token scope for Jamf Pro and Microsoft Graph APIs

### DIFF
--- a/apiintegrations/apihandler/apihandler.go
+++ b/apiintegrations/apihandler/apihandler.go
@@ -19,6 +19,7 @@ type APIHandler interface {
 	GetAcceptHeader() string
 	GetDefaultBaseDomain() string
 	GetOAuthTokenEndpoint() string
+	GetOAuthTokenScope() string
 	GetBearerTokenEndpoint() string
 	GetTokenRefreshEndpoint() string
 	GetTokenInvalidateEndpoint() string

--- a/apiintegrations/jamfpro/jamfpro_api_handler_constants.go
+++ b/apiintegrations/jamfpro/jamfpro_api_handler_constants.go
@@ -5,6 +5,7 @@ const (
 	APIName                            = "jamf pro"                      // APIName: represents the name of the API.
 	DefaultBaseDomain                  = ".jamfcloud.com"                // DefaultBaseDomain: represents the base domain for the jamf instance.
 	OAuthTokenEndpoint                 = "/api/oauth/token"              // OAuthTokenEndpoint: The endpoint to obtain an OAuth token.
+	OAuthTokenScope                    = ""                              // OAuthTokenScope: Not used for Jamf.
 	BearerTokenEndpoint                = "/api/v1/auth/token"            // BearerTokenEndpoint: The endpoint to obtain a bearer token.
 	TokenRefreshEndpoint               = "/api/v1/auth/keep-alive"       // TokenRefreshEndpoint: The endpoint to refresh an existing token.
 	TokenInvalidateEndpoint            = "/api/v1/auth/invalidate-token" // TokenInvalidateEndpoint: The endpoint to invalidate an active token.
@@ -21,6 +22,11 @@ func (j *JamfAPIHandler) GetDefaultBaseDomain() string {
 // GetOAuthTokenEndpoint returns the endpoint for obtaining an OAuth token. Used for constructing API URLs for the http client.
 func (j *JamfAPIHandler) GetOAuthTokenEndpoint() string {
 	return OAuthTokenEndpoint
+}
+
+// GetOAuthTokenScope returns the scope for the OAuth token scope
+func (j *JamfAPIHandler) GetOAuthTokenScope() string {
+	return OAuthTokenScope
 }
 
 // GetBearerTokenEndpoint returns the endpoint for obtaining a bearer token. Used for constructing API URLs for the http client.

--- a/apiintegrations/msgraph/msgraph_api_handler_constants.go
+++ b/apiintegrations/msgraph/msgraph_api_handler_constants.go
@@ -3,15 +3,16 @@ package msgraph
 
 // Endpoint constants represent the URL suffixes used for graph API token interactions.
 const (
-	APIName                            = "microsoft graph"     // APIName: represents the name of the API.
-	DefaultBaseDomain                  = "graph.microsoft.com" // DefaultBaseDomain: represents the base domain for the graph instance.
-	OAuthTokenEndpoint                 = "/oauth2/v2.0/token"  // OAuthTokenEndpoint: The endpoint to obtain an OAuth token.
-	BearerTokenEndpoint                = ""                    // BearerTokenEndpoint: The endpoint to obtain a bearer token.
-	TokenRefreshEndpoint               = "graph.microsoft.com" // TokenRefreshEndpoint: The endpoint to refresh an existing token.
-	TokenInvalidateEndpoint            = "graph.microsoft.com" // TokenInvalidateEndpoint: The endpoint to invalidate an active token.
-	BearerTokenAuthenticationSupport   = true                  // BearerTokenAuthSuppport: A boolean to indicate if the API supports bearer token authentication.
-	OAuthAuthenticationSupport         = true                  // OAuthAuthSuppport: A boolean to indicate if the API supports OAuth authentication.
-	OAuthWithCertAuthenticationSupport = true                  // OAuthWithCertAuthSuppport: A boolean to indicate if the API supports OAuth with client certificate authentication.
+	APIName                            = "microsoft graph"                      // APIName: represents the name of the API.
+	DefaultBaseDomain                  = "graph.microsoft.com"                  // DefaultBaseDomain: represents the base domain for the graph instance.
+	OAuthTokenEndpoint                 = "/oauth2/v2.0/token"                   // OAuthTokenEndpoint: The endpoint to obtain an OAuth token.
+	OAuthTokenScope                    = "https://graph.microsoft.com/.default" // OAuthTokenScope: The scope for the OAuth token.
+	BearerTokenEndpoint                = "graph.microsoft.com"                  // BearerTokenEndpoint: The endpoint to obtain a bearer token.
+	TokenRefreshEndpoint               = "graph.microsoft.com"                  // TokenRefreshEndpoint: The endpoint to refresh an existing token.
+	TokenInvalidateEndpoint            = "graph.microsoft.com"                  // TokenInvalidateEndpoint: The endpoint to invalidate an active token.
+	BearerTokenAuthenticationSupport   = true                                   // BearerTokenAuthSuppport: A boolean to indicate if the API supports bearer token authentication.
+	OAuthAuthenticationSupport         = true                                   // OAuthAuthSuppport: A boolean to indicate if the API supports OAuth authentication.
+	OAuthWithCertAuthenticationSupport = true                                   // OAuthWithCertAuthSuppport: A boolean to indicate if the API supports OAuth with client certificate authentication.
 )
 
 // GetDefaultBaseDomain returns the default base domain used for constructing API URLs to the http client.
@@ -22,6 +23,11 @@ func (g *GraphAPIHandler) GetDefaultBaseDomain() string {
 // GetOAuthTokenEndpoint returns the endpoint for obtaining an OAuth token. Used for constructing API URLs for the http client.
 func (g *GraphAPIHandler) GetOAuthTokenEndpoint() string {
 	return OAuthTokenEndpoint
+}
+
+// GetOAuthTokenScope returns the scope for the OAuth token scope
+func (g *GraphAPIHandler) GetOAuthTokenScope() string {
+	return OAuthTokenScope
 }
 
 // GetBearerTokenEndpoint returns the endpoint for obtaining a bearer token. Used for constructing API URLs for the http client.

--- a/apiintegrations/temp/http_client_auth_token.go.back
+++ b/apiintegrations/temp/http_client_auth_token.go.back
@@ -1,0 +1,171 @@
+// http_client_oauth.go
+/* The http_client_auth package focuses on authentication mechanisms for an HTTP client.
+It provides structures and methods for handling OAuth-based authentication
+*/
+package http_client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+const Authority = "https://login.microsoftonline.com/"
+const Scope = "https://graph.microsoft.com/.default"
+
+// OAuthResponse represents the response structure when obtaining an OAuth access token.
+type OAuthResponse struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+// ObtainOauthTokenWithApp fetches an OAuth access token using client credentials.
+func (c *Client) ObtainOauthTokenWithApp(tenantID, clientID, clientSecret string) (*OAuthResponse, error) {
+	endpoint := fmt.Sprintf("%s%s/oauth2/v2.0/token", Authority, tenantID)
+
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", Scope)
+	data.Set("client_secret", clientSecret)
+	data.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Debug: Print the entire raw response body for inspection
+	c.logger.Debug("Raw response body: %s\n", string(bodyBytes))
+
+	// Create a new reader from the body bytes for json unmarshalling
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	oauthResp := &OAuthResponse{}
+	err = json.NewDecoder(bodyReader).Decode(oauthResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if oauthResp.Error != "" {
+		return nil, fmt.Errorf("error obtaining OAuth token: %s", oauthResp.Error)
+	}
+
+	// Calculate and format token expiration time
+	expiresIn := time.Duration(oauthResp.ExpiresIn) * time.Second
+	expirationTime := time.Now().Add(expiresIn)
+	formattedExpirationTime := expirationTime.Format(time.RFC1123)
+
+	// Log the token life expiry details in a human-readable format
+	c.logger.Debug("The OAuth token obtained is: ",
+		"Valid for", expiresIn.String(),
+		"Expires at", formattedExpirationTime)
+
+	return oauthResp, nil
+}
+
+// ObtainOauthTokenWithCertificate fetches an OAuth access token using a certificate.
+func (c *Client) ObtainOauthTokenWithCertificate(tenantID, clientID, thumbprint, keyFile string) (*OAuthResponse, error) {
+	endpoint := fmt.Sprintf("%s%s/oauth2/v2.0/token", Authority, tenantID)
+
+	// Load the certificate
+	certData, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read certificate file: %v", err)
+	}
+
+	cert, err := tls.X509KeyPair(certData, certData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+
+	// Create a custom HTTP client with the certificate
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(certData)
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            certPool,
+		InsecureSkipVerify: true, // Depending on your requirements, you might want to adjust this
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	// Prepare request data
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	data.Set("scope", Scope)
+	data.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	data.Set("client_assertion", thumbprint) // You might need to adjust this according to your requirements
+	data.Set("grant_type", "client_credentials")
+
+	req, err := http.NewRequest("POST", endpoint, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Debug: Print the entire raw response body for inspection
+	c.logger.Debug("Raw response body: %s\n", string(bodyBytes))
+
+	bodyReader := bytes.NewReader(bodyBytes)
+	oauthResp := &OAuthResponse{}
+	err = json.NewDecoder(bodyReader).Decode(oauthResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if oauthResp.Error != "" {
+		return nil, fmt.Errorf("error obtaining OAuth token: %s", oauthResp.Error)
+	}
+
+	expiresIn := time.Duration(oauthResp.ExpiresIn) * time.Second
+	expirationTime := time.Now().Add(expiresIn)
+	formattedExpirationTime := expirationTime.Format(time.RFC1123)
+	c.logger.Debug("The OAuth token obtained is: ",
+		"Valid for", expiresIn.String(),
+		"Expires at", formattedExpirationTime)
+
+	return oauthResp, nil
+}
+
+// GetOAuthCredentials retrieves the current OAuth credentials (Client ID and Client Secret)
+// set for the client instance. Used for test cases.
+func (c *Client) GetOAuthCredentials() OAuthCredentials {
+	return c.OAuthCredentials
+}

--- a/apiintegrations/temp/http_client_auth_token_management.go.back
+++ b/apiintegrations/temp/http_client_auth_token_management.go.back
@@ -1,0 +1,48 @@
+// http_client_auth_token_management.go
+package http_client
+
+import (
+	"fmt"
+	"time"
+)
+
+// TokenResponse represents the structure of a token response from the API.
+type TokenResponse struct {
+	Token   string    `json:"token"`
+	Expires time.Time `json:"expires"`
+}
+
+// ValidAuthTokenCheck checks if the current token is valid and not close to expiry.
+// If the token is invalid or close to expiry, it tries to obtain a new token.
+func (c *Client) ValidAuthTokenCheck() (bool, error) {
+	if c.Token == "" || time.Until(c.Expiry) < c.config.TokenRefreshBufferPeriod {
+		var oauthResp *OAuthResponse
+		var err error
+
+		switch c.AuthMethod {
+		case "oauthApp":
+			// Obtain token using OAuth App credentials
+			oauthResp, err = c.ObtainOauthTokenWithApp(c.TenantID, c.OAuthCredentials.ClientID, c.OAuthCredentials.ClientSecret)
+
+		case "oauthCertificate":
+			// Obtain token using OAuth Certificate credentials
+			oauthResp, err = c.ObtainOauthTokenWithCertificate(c.TenantID, c.OAuthCredentials.ClientID, c.OAuthCredentials.CertThumbprint, c.OAuthCredentials.CertificatePath)
+
+		default:
+			return false, fmt.Errorf("unknown auth method: %s", c.AuthMethod)
+		}
+
+		if err != nil {
+			return false, fmt.Errorf("failed to obtain new token: %w", err)
+		}
+
+		// Update the token and expiry time if a new token was obtained
+		if oauthResp != nil {
+			c.Token = oauthResp.AccessToken
+			expiresIn := time.Duration(oauthResp.ExpiresIn) * time.Second
+			c.Expiry = time.Now().Add(expiresIn)
+		}
+	}
+
+	return true, nil
+}

--- a/authenticationhandler/auth_oauth.go
+++ b/authenticationhandler/auth_oauth.go
@@ -33,15 +33,19 @@ type OAuthResponse struct {
 // ObtainOAuthToken fetches an OAuth access token using the provided client ID and client secret.
 // It updates the AuthTokenHandler's Token and Expires fields with the obtained values.
 func (h *AuthTokenHandler) ObtainOAuthToken(apiHandler apihandler.APIHandler, httpClient *http.Client, clientID, clientSecret string) error {
-	// Use the APIHandler's method to get the OAuth token endpoint
+	// Get the OAuth token endpoint from the APIHandler
 	oauthTokenEndpoint := apiHandler.GetOAuthTokenEndpoint()
 
 	// Construct the full authentication endpoint URL
 	authenticationEndpoint := apiHandler.ConstructAPIAuthEndpoint(h.InstanceName, oauthTokenEndpoint, h.Logger)
 
+	// Get the OAuth token scope from the APIHandler
+	oauthTokenScope := apiHandler.GetOAuthTokenScope()
+
 	data := url.Values{}
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
+	data.Set("scope", oauthTokenScope)
 	data.Set("grant_type", "client_credentials")
 
 	h.Logger.Debug("Attempting to obtain OAuth token", zap.String("ClientID", clientID))


### PR DESCRIPTION
# Change

Add OAuth token scope for Jamf Pro and Microsoft Graph APIs to the API handler. required by msgraph for auth and a placeholder within jamf pro to satisfy the api handler interface

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
