### PR TITLE
Refactor GraphAPIHandler in msgraph_api_handler.go and msgraph_api_ur…

### DIFF
--- a/apiintegrations/msgraph/msgraph_api_handler.go
+++ b/apiintegrations/msgraph/msgraph_api_handler.go
@@ -6,6 +6,7 @@ import "github.com/deploymenttheory/go-api-http-client/logger"
 // GraphAPIHandler implements the APIHandler interface for the graph Pro API.
 type GraphAPIHandler struct {
 	OverrideBaseDomain string        // OverrideBaseDomain is used to override the base domain for URL construction.
-	InstanceName       string        // InstanceName is the name of the graph instance.
+	TenantID           string        // TenantID used for constructing the authentication endpoint.
+	TenantName         string        // TenantName used for constructing the authentication endpoint.
 	Logger             logger.Logger // Logger is the structured logger used for logging.
 }

--- a/apiintegrations/msgraph/msgraph_api_url.go
+++ b/apiintegrations/msgraph/msgraph_api_url.go
@@ -18,24 +18,24 @@ func (g *GraphAPIHandler) SetBaseDomain() string {
 }
 
 // ConstructAPIResourceEndpoint constructs the full URL for a graph API resource endpoint path and logs the URL.
-func (g *GraphAPIHandler) ConstructAPIResourceEndpoint(instanceName string, endpointPath string, log logger.Logger) string {
+func (g *GraphAPIHandler) ConstructAPIResourceEndpoint(tenantName string, endpointPath string, log logger.Logger) string {
 	urlBaseDomain := g.SetBaseDomain()
-	url := fmt.Sprintf("https://%s%s%s", instanceName, urlBaseDomain, endpointPath)
+	url := fmt.Sprintf("https://%s%s%s", tenantName, urlBaseDomain, endpointPath)
 	g.Logger.Debug(fmt.Sprintf("Constructed %s API resource endpoint URL", APIName), zap.String("URL", url))
 	return url
 }
 
 // ConstructAPIAuthEndpoint constructs the full URL for the Microsoft Graph API authentication endpoint.
-// It uses the provided tenant name and endpoint path and logs the constructed URL.
-func (g *GraphAPIHandler) ConstructAPIAuthEndpoint(tenantName string, endpointPath string, log logger.Logger) string {
+// It uses the provided tenant ID and endpoint path and logs the constructed URL.
+func (g *GraphAPIHandler) ConstructAPIAuthEndpoint(tenantID string, endpointPath string, log logger.Logger) string {
 	// The base URL for the Microsoft Graph API authentication endpoint.
 	const baseURL = "https://login.microsoftonline.com"
 
-	// Construct the full URL by combining the base URL, tenant name, and endpoint path.
-	url := fmt.Sprintf("%s/%s%s", baseURL, tenantName, endpointPath)
+	// Construct the full URL by combining the base URL, tenant ID, and endpoint path.
+	url := fmt.Sprintf("%s/%s%s", baseURL, tenantID, endpointPath)
 
 	// Log the constructed URL for debugging purposes.
-	log.Debug(fmt.Sprintf("Constructed Microsoft Graph API authentication URL"), zap.String("URL", url))
+	log.Debug("constructed Microsoft Graph API authentication URL", zap.String("URL", url))
 
 	return url
 }

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -22,15 +22,15 @@ import (
 
 // Client represents an HTTP client to interact with a specific API.
 type Client struct {
-	AuthMethod         string       // Specifies the authentication method: "bearer" or "oauth"
-	Token              string       // Authentication Token
-	Expiry             time.Time    // Expiry time set for the auth token
-	httpClient         *http.Client // Internal HTTP client
-	clientConfig       ClientConfig
-	Logger             logger.Logger
-	ConcurrencyHandler *concurrency.ConcurrencyHandler
-	APIHandler         apihandler.APIHandler // APIHandler interface used to define which API handler to use
-	AuthTokenHandler   *authenticationhandler.AuthTokenHandler
+	AuthMethod         string                                  // Specifies the authentication method: "bearer" or "oauth"
+	Token              string                                  // Authentication Token
+	Expiry             time.Time                               // Expiry time set for the auth token
+	httpClient         *http.Client                            // Internal HTTP client
+	clientConfig       ClientConfig                            // HTTP Client configuration
+	Logger             logger.Logger                           // Logger for logging messages
+	ConcurrencyHandler *concurrency.ConcurrencyHandler         // ConcurrencyHandler for managing concurrent requests
+	APIHandler         apihandler.APIHandler                   // APIHandler interface used to define which API handler to use
+	AuthTokenHandler   *authenticationhandler.AuthTokenHandler // AuthTokenHandler for managing authentication
 }
 
 // Config holds configuration options for the HTTP Client.
@@ -148,10 +148,8 @@ func BuildClient(config ClientConfig) (*Client, error) {
 
 	// Create a new HTTP client with the provided configuration.
 	client := &Client{
-		APIHandler: apiHandler,
-		//InstanceName:       config.Environment.InstanceName,
-		AuthMethod: authMethod,
-		//OverrideBaseDomain: config.Environment.OverrideBaseDomain,
+		APIHandler:         apiHandler,
+		AuthMethod:         authMethod,
 		httpClient:         httpClient,
 		clientConfig:       config,
 		Logger:             log,


### PR DESCRIPTION
…l.go to use TenantID and TenantName for constructing URLs

# Change

To support graph api auth using the url pattern 
'https://login.microsoftonline.com/<your tenant id here>/oauth2/v2.0/token'

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
