### PR TITLE
Fix error handling in BasicAuthTokenAcquisition function

### DIFF
--- a/authenticationhandler/basicauthentication.go
+++ b/authenticationhandler/basicauthentication.go
@@ -34,7 +34,7 @@ func (h *AuthTokenHandler) BasicAuthTokenAcquisition(apiHandler apihandler.APIHa
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		h.Logger.LogError("authentication_request_error", "POST", authenticationEndpoint, resp.StatusCode, resp.Status, err, "Failed to make request for token")
+		h.Logger.LogError("authentication_request_error", "POST", authenticationEndpoint, 0, "", err, "Failed to make request for token")
 		return err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
# Change

The updates prevents accessing properties of resp if resp is nil due to an error. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
