### PR TITLE
Bug fix: 

### DIFF
--- a/authenticationhandler/tokenmanager.go
+++ b/authenticationhandler/tokenmanager.go
@@ -25,7 +25,12 @@ func (h *AuthTokenHandler) CheckAndRefreshAuthToken(apiHandler apihandler.APIHan
 
 		refreshAttempts++
 		if refreshAttempts >= maxConsecutiveRefreshAttempts {
-			return false, fmt.Errorf("exceeded maximum consecutive token refresh attempts (%d): token lifetime is likely too short", maxConsecutiveRefreshAttempts)
+			return false, fmt.Errorf(
+				"exceeded maximum consecutive token refresh attempts (%d): access token lifetime (%s) is likely too short compared to the buffer period (%s) configured for token refresh",
+				maxConsecutiveRefreshAttempts,
+				h.Expires.Sub(time.Now()).String(), // Access token lifetime
+				tokenRefreshBufferPeriod.String(),  // Configured buffer period
+			)
 		}
 	}
 


### PR DESCRIPTION
# Change
Bug Fix Notes for PR
Issue Description:
The root cause of the issue is that the token lifetime is shorter than the buffer period set for token refresh. This causes the token to never be considered valid by the client, triggering a refresh immediately after acquiring a new token. This creates a loop where the token is continually refreshed but never actually used for requests.

Breakdown of the Issue:

Token Lifetime and Buffer Period:

The token lifetime was initially set to 60 seconds.
The buffer period for token refresh (TokenRefreshBufferPeriod) is likely greater than 60 seconds (e.g., 5 minutes by default).

Client Behavior:

When the token lifetime is less than the buffer period, the client sees the token as invalid immediately after it is acquired because it is already within the buffer period for needing a refresh.
This leads to the client continuously refreshing the token without ever considering it valid for use.
Infinite Refresh Loop:

This results in an infinite loop of token refresh attempts, which eventually fails when the maximum number of consecutive refresh attempts is reached, or when other conditions cause the client to error out.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
