### PR TITLE
Fix: Multipart request now uses httptimeout, added funcs to expose that to the SDK

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -55,7 +55,7 @@ type ClientConfig struct {
 	EnableDynamicRateLimiting bool `json:"enable_dynamic_rate_limiting"`
 
 	// CustomTimeout // TODO also because I don't know.
-	CustomTimeout time.Duration
+	Timeout time.Duration
 
 	// TokenRefreshBufferPeriod is the duration of time before the token expires in which it's deemed
 	// more sensible to replace the token rather then carry on using it.
@@ -107,11 +107,11 @@ func (c *ClientConfig) Build() (*Client, error) {
 
 	httpClient := c.HTTP
 
-	if c.CustomTimeout == 0 {
-		c.CustomTimeout = DefaultTimeout
+	if c.Timeout == 0 {
+		httpClient.Timeout = DefaultTimeout
+	} else {
+		httpClient.Timeout = c.Timeout
 	}
-
-	httpClient.Timeout = c.CustomTimeout
 
 	cookieJar, err := cookiejar.New(nil)
 	if err != nil {

--- a/httpclient/config_validation.go
+++ b/httpclient/config_validation.go
@@ -66,7 +66,7 @@ func LoadConfigFromEnv() (*ClientConfig, error) {
 		MaxRetryAttempts:            getEnvAsInt("MAX_RETRY_ATTEMPTS", DefaultMaxRetryAttempts),
 		MaxConcurrentRequests:       getEnvAsInt("MAX_CONCURRENT_REQUESTS", DefaultMaxConcurrentRequests),
 		EnableDynamicRateLimiting:   getEnvAsBool("ENABLE_DYNAMIC_RATE_LIMITING", DefaultEnableDynamicRateLimiting),
-		CustomTimeout:               getEnvAsDuration("CUSTOM_TIMEOUT", DefaultCustomTimeout),
+		Timeout:                     getEnvAsDuration("CUSTOM_TIMEOUT", DefaultCustomTimeout),
 		TokenRefreshBufferPeriod:    getEnvAsDuration("TOKEN_REFRESH_BUFFER_PERIOD", DefaultTokenRefreshBufferPeriod),
 		TotalRetryDuration:          getEnvAsDuration("TOTAL_RETRY_DURATION", DefaultTotalRetryDuration),
 		EnableConcurrencyManagement: getEnvAsBool("ENABLE_CONCURRENCY_MANAGEMENT", DefaultEnableConcurrencyManagement),
@@ -111,7 +111,7 @@ func (c ClientConfig) validateClientConfig() error {
 		}
 	}
 
-	if c.CustomTimeout.Seconds() < 0 {
+	if c.Timeout.Seconds() < 0 {
 		return errors.New("timeout cannot be less than 0 seconds")
 	}
 
@@ -139,7 +139,7 @@ func (c *ClientConfig) SetDefaultValuesClientConfig() {
 	setDefaultInt(&c.MaxRetryAttempts, DefaultMaxRetryAttempts, 1)
 	setDefaultInt(&c.MaxConcurrentRequests, DefaultMaxConcurrentRequests, 1)
 	setDefaultBool(&c.EnableDynamicRateLimiting, DefaultEnableDynamicRateLimiting)
-	setDefaultDuration(&c.CustomTimeout, DefaultCustomTimeout)
+	setDefaultDuration(&c.Timeout, DefaultCustomTimeout)
 	setDefaultDuration(&c.TokenRefreshBufferPeriod, DefaultTokenRefreshBufferPeriod)
 	setDefaultDuration(&c.TotalRetryDuration, DefaultTotalRetryDuration)
 	setDefaultBool(&c.EnableConcurrencyManagement, DefaultEnableConcurrencyManagement)

--- a/httpclient/multipartrequest.go
+++ b/httpclient/multipartrequest.go
@@ -80,11 +80,9 @@ func (c *Client) DoMultiPartRequest(method, endpoint string, files map[string][]
 	var ctx context.Context
 	var cancel context.CancelFunc
 
-	c.Sugar.Debugf("TIMEOUT: %v", c.config.CustomTimeout)
-
-	if c.config.CustomTimeout > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), c.config.CustomTimeout)
-		c.Sugar.Infow("Using timeout context for multipart request", zap.Duration("custom_timeout_seconds", c.config.CustomTimeout))
+	if c.http.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), c.http.Timeout)
+		c.Sugar.Infow("Using timeout context for multipart request", zap.Duration("custom_timeout_seconds", c.http.Timeout))
 	} else {
 		ctx = context.Background()
 		cancel = func() {}

--- a/httpclient/multipartrequest.go
+++ b/httpclient/multipartrequest.go
@@ -80,6 +80,8 @@ func (c *Client) DoMultiPartRequest(method, endpoint string, files map[string][]
 	var ctx context.Context
 	var cancel context.CancelFunc
 
+	c.Sugar.Debugf("TIMEOUT: %v", c.config.CustomTimeout)
+
 	if c.config.CustomTimeout > 0 {
 		ctx, cancel = context.WithTimeout(context.Background(), c.config.CustomTimeout)
 		c.Sugar.Infow("Using timeout context for multipart request", zap.Duration("custom_timeout_seconds", c.config.CustomTimeout))

--- a/httpclient/timeouts.go
+++ b/httpclient/timeouts.go
@@ -13,3 +13,7 @@ func (c *Client) ModifyHttpTimeout(newTimeout time.Duration) {
 func (c *Client) ResetTimeout() {
 	c.http.Timeout = DefaultTimeout
 }
+
+func (c *Client) HttpTimeout() time.Duration {
+	return c.http.Timeout
+}

--- a/httpclient/timeouts.go
+++ b/httpclient/timeouts.go
@@ -1,22 +1,15 @@
 package httpclient
 
 import (
-	"sync"
 	"time"
 )
 
-var mu sync.Mutex
-
 // Amends the HTTP timeout time
 func (c *Client) ModifyHttpTimeout(newTimeout time.Duration) {
-	mu.Lock()
-	defer mu.Unlock()
 	c.http.Timeout = newTimeout
 }
 
 // Resets HTTP timeout time back to 10 seconds
 func (c *Client) ResetTimeout() {
-	mu.Lock()
-	defer mu.Unlock()
 	c.http.Timeout = DefaultTimeout
 }


### PR DESCRIPTION
Fix: Multipart request now uses httptimeout, added funcs to expose that to the SDK