### PR TITLE
fix: store raw response in APIError during JSON parsing

### DIFF
--- a/response/error.go
+++ b/response/error.go
@@ -17,12 +17,22 @@ import (
 
 // APIError represents an api error response.
 type APIError struct {
-	StatusCode  int      `json:"status_code"`       // HTTP status code
-	Method      string   `json:"method"`            // HTTP method used for the request
-	URL         string   `json:"url"`               // The URL of the HTTP request
+	StatusCode  int      `json:"status_code"` // HTTP status code
+	Method      string   `json:"method"`      // HTTP method used for the request
+	URL         string   `json:"url"`         // The URL of the HTTP request
+	HTTPStatus  int      `json:"httpStatus,omitempty"`
+	Errors      []Errors `json:"errors,omitempty"`
 	Message     string   `json:"message"`           // Summary of the error
 	Details     []string `json:"details,omitempty"` // Detailed error messages, if any
 	RawResponse string   `json:"raw_response"`      // Raw response body for debugging
+}
+
+// Errors represents individual error details within an API error response.
+type Errors struct {
+	Code        string  `json:"code,omitempty"`
+	Field       string  `json:"field,omitempty"`
+	Description string  `json:"description,omitempty"`
+	ID          *string `json:"id,omitempty"`
 }
 
 // Error returns a string representation of the APIError, making it compatible with the error interface.
@@ -74,15 +84,14 @@ func HandleAPIErrorResponse(resp *http.Response, sugar *zap.SugaredLogger) *APIE
 
 // parseJSONResponse attempts to parse the JSON error response and update the APIError structure.
 func parseJSONResponse(bodyBytes []byte, apiError *APIError) {
-	apiError.RawResponse = string(bodyBytes)
-
 	if err := json.Unmarshal(bodyBytes, apiError); err != nil {
+		apiError.RawResponse = string(bodyBytes)
 	} else {
 		if apiError.Message == "" {
 			apiError.Message = "An unknown error occurred"
 		}
-	}
 
+	}
 }
 
 // parseXMLResponse dynamically parses XML error responses and accumulates potential error messages.


### PR DESCRIPTION
# Change

>Thank you for your contribution !
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Type of Change

Been meaning to dig into this one for a while... :-) When working with endpoints that give JSON responses, `raw_response` was being returned as an empty string, for example:

```
jamfpro_sso_settings.okta: Modifying... [id=jamfpro_sso_settings_singleton]
jamfpro_sso_settings.okta: Still modifying... [id=jamfpro_sso_settings_singleton, 00m10s elapsed]
╷
│ Error: failed to update SSO settings: failed to update sso settings, error: {"status_code":400,"method":"PUT","url":"https://ajksxfz.fleet.jamf.build/api/v3/sso","message":"API Error Response","raw_response":""}
```

This change just makes sure we always output the raw response. I think it fails because the `APIError` struct does not match the fields we get from a Jamf Pro JSON error response. But I didn't want to change that in case it breaks response handling from other APIs this client is used with.

Now a TF error looks like this instead (populated `raw_response` field) which is extremely helpful for debugging/troubleshooting provider/API/TF module issues downstream:

```
│ Error: failed to update SSO settings: failed to update sso settings, error: {"status_code":400,"method":"PUT","url":"https://ajksxfz.fleet.jamf.build/api/v3/sso","message":"API Error Response","raw_response":"{\n  \"httpStatus\" : 400,\n  \"errors\" : [ {\n    \"code\" : \"INVALID_METADATA\",\n    \"description\" : \"Unable to unmarshall metadata\",\n    \"id\" : null,\n    \"field\" : \"idpUrl\"\n  } ]\n}"}
```

Please **DELETE** options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (readme)
- [x] I did format my code
